### PR TITLE
Fix for supportconfigs with .tar.bz2 extension

### DIFF
--- a/bin/supportconfig-tmux
+++ b/bin/supportconfig-tmux
@@ -22,7 +22,11 @@ main () {
 
     unpacked="${supportconfig##*/}"
     if ! [ -d "$supportconfig" ]; then
-        unpacked="${unpacked%.tbz}"
+        if [[ "$unpacked" == *.tbz ]]; then
+            unpacked="${unpacked%.tbz}"
+        elif [[ "$unpacked" == *.tar.bz2 ]]; then
+            unpacked="${unpacked%.tar.bz2}"
+        fi
         unpack-supportconfig -d "$supportconfig"
         if ! [ -d "$unpacked" ]; then
             echo "Failed to unpack $supportconfig; aborting!" >&2


### PR DESCRIPTION
supportconfig-tmux unpacks but stops with:
Failed to unpack nts_SR1234.tar.bz2; aborting!